### PR TITLE
Dead reckoning update

### DIFF
--- a/src/SailawayNMEAgui_impl.cpp
+++ b/src/SailawayNMEAgui_impl.cpp
@@ -737,8 +737,10 @@ void Dlg::OnTimerData(wxTimerEvent& event) {
 			NMEASend(nmea);
 			startDR = false;
 			m_llTimerStartTick = wxGetUTCTimeMillis();
-			m_status->SetValue("DR Update");
-		}		
+			double sec = llElapsedDownloadTime.ToDouble() / 1000;
+			wxString update = wxString::Format("DR Update: % 2.0f:%02.0f", floor(sec/60), floor(fmod(sec,60)));
+			m_status->SetValue(update);
+		}
 	}
   
 	event.Skip();

--- a/src/SailawayNMEAgui_impl.cpp
+++ b/src/SailawayNMEAgui_impl.cpp
@@ -591,38 +591,14 @@ void Dlg::LoadBoatData()
 
 	}
 
+boat Dlg::FindNewBoatposition(boat drBoat) {
+	boat newbtDR = myBoat;
 
-boat Dlg::FindNewBoatposition(boat drBoat)
-{
-	boat newbtDR;
-	double lat = drBoat.coordLat;
-	double lon = drBoat.coordLon;
-	double hdg = drBoat.heading;
-	double spd = (drBoat.groundSpeed)/60/6; // to change later to allow for download interval
-	double depth = drBoat.depth;
+	double hoursSinceDownload = llElapsedDownloadTime.ToDouble() / (60*60*1000);
+	double distance = myBoat.groundSpeed * hoursSinceDownload;
 
-	//bool destLoxodrome(double lat1, double lon1, double brng, double dist, double* lat2, double* lon2);
-	destLoxodrome(lat, lon, hdg, spd, &newbtDR.coordLat, &newbtDR.coordLon);
-	
-	newbtDR.heading = hdg;
-	newbtDR.magHdg = drBoat.magHdg;
-	newbtDR.waterSpeed = drBoat.waterSpeed;	
-	newbtDR.groundSpeed = drBoat.groundSpeed;
-	//
-	newbtDR.depth = drBoat.depth;
-	newbtDR.TransducerDepth = drBoat.TransducerDepth;
-	//
-	newbtDR.courseOverGround = drBoat.courseOverGround;			
-	newbtDR.magneticCourseOverGround = drBoat.magneticCourseOverGround;
-	//
-	//
-	newbtDR.trueWindSpeed = drBoat.trueWindSpeed;
-	newbtDR.trueWindAngle = drBoat.trueWindAngle;
-	newbtDR.ApparentWindSpeed = drBoat.ApparentWindSpeed;
-	newbtDR.ApparentWindAngle = drBoat.ApparentWindAngle;
-	//
-	//
-	//
+	destLoxodrome(myBoat.coordLat, myBoat.coordLon, myBoat.heading, distance, &newbtDR.coordLat, &newbtDR.coordLon);
+
 	return newbtDR;
 }
 
@@ -690,7 +666,7 @@ void Dlg::OnStartServer(wxCommandEvent& event)
 	useDR = m_checkBoxDR->GetValue();
 
 	LoadBoatData();
-
+	myBoat = drBoat;
 	serverRunning = true;
 
 	Init_Datagram_Socket();
@@ -750,6 +726,7 @@ void Dlg::OnTimerData(wxTimerEvent& event) {
 		llElapsedDownloadTime = m_llTimerDownloadStopTick - m_llTimerDownloadStartTick;
 		if (llElapsedDownloadTime > REQUEST_RATE) {
 			LoadBoatData();
+			myBoat = drBoat;
 			NMEASend(nmea);
 			startDR = false;
 			m_llTimerStartTick = wxGetUTCTimeMillis();

--- a/src/SailawayNMEAgui_impl.h
+++ b/src/SailawayNMEAgui_impl.h
@@ -81,7 +81,7 @@ enum
 };
 
 #define REQUEST_RATE  600000
-#define DEAD_RECKONING_RATE 10000
+#define DEAD_RECKONING_RATE 1000
 #define MS_TO_KNOTS 1.94384
 
 struct boat


### PR DESCRIPTION
This is the idea I was trying to explain to increase the accuracy of dead reckoning.

For unknown reasons, when the dead reckoning rate is set to one second, on my computer the DR update happens at about 2 second intervals. When the DR rate is set to 10 seconds, on my computer the DR update happens at about 16 second intervals. If OpenCPN does not get an update after about 8 seconds, it assumes it has lost the connection to the GPS. This cause the connection icon in the top right (and Dashboard data if that is enabled) to toggle off and on. A faster (1 second, for example) update rate solves the lost connection issue. The unstable timing of the update is also used to calculate the new DR position based on the previous DR position. This is very inaccurate without stable timing, and the errors accumulate with faster updates.

This merge request changes the DR position calculation to be based on the time since the last data download from Sailaway and the position at the time that download occurred. This new DR position calculation is not affected by any irregularities in the DR update rate. I also restored the 1 second nominal update rate to fix the lost connection problem, and I added a "time since last data download" counter to the DR status display.